### PR TITLE
chore: add default_version and codeowner_team to .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -6,8 +6,10 @@
     "issue_tracker": "https://github.com/googleapis/python-iamlogging/issues",
     "release_level": "beta",
     "language": "python",
-    "library_type" : "OTHER",
+    "library_type": "OTHER",
     "repo": "googleapis/python-iam-logging",
     "distribution_name": "google-cloud-iam-logging",
-    "api_id": ""
-  }
+    "api_id": "",
+    "default_version": "",
+    "codeowner_team": ""
+}

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -10,6 +10,6 @@
     "repo": "googleapis/python-iam-logging",
     "distribution_name": "google-cloud-iam-logging",
     "api_id": "",
-    "default_version": "",
+    "default_version": "v1",
     "codeowner_team": ""
 }


### PR DESCRIPTION
By default the code owner will be googleapis/yoshi-python. This change is needed for the following synthtool PRs.

googleapis/synthtool#1201
googleapis/synthtool#1114