### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "iamlogging",
     "name_pretty": "IAM Logging Protos",
     "product_documentation": "https://cloud.google.com/iam/docs/audit-logging",
-    "client_documentation": "https://googleapis.dev/python/iamlogging/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/iamlogging/latest",
     "issue_tracker": "https://github.com/googleapis/python-iamlogging/issues",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ This package contains generated Python types for ``google.iam.v1.logging``.
    :target: https://pypi.org/project/google-cloud-iam-logging/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-iam-logging.svg
    :target: https://pypi.org/project/google-cloud-iam-logging/
-.. _Client Library Documentation: https://googleapis.dev/python/iamlogging/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/iamlogging/latest
 .. _Product Documentation: https://cloud.google.com/iam/docs/audit-logging
 
 


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.